### PR TITLE
Changed IP address of h2.hitecnologys.org

### DIFF
--- a/nodes
+++ b/nodes
@@ -29,7 +29,6 @@ fc3a:49cf:2dc8:7964:422a:61cd:e9f6:6e59 fvz-rec-tr-ist-01 fvz-rec-tr-ist-01.h.dn
 fc3a:956e:4b69:1c1e:5ebc:11a5:3e71:3e7e uppit.us
 fc3b:f894:81ab:a060:149c:7d61:87b7:2ef9 cjdns.ve7alb.ca
 fc42:ba29:491e:9ef5:2ce1:6fd0:7f9f:9c09 us.ga.atlanta.gme.hype
-fc42:efb7:1721:20ee:b651:2554:734b:7eab h2.hitecnologys.org
 fc43:d88c:39a1:8746:538:b247:4695:cdb6 fvz-rec-vn-sgn-01 fvz-rec-vn-sgn-01.h.dnsrec.meo.ws
 fc46:d480:61bb:658e:8936:4547:70ea:f628 rainbow.exit.li
 fc48:238f:1b3b:e867:4f77:3fe1:8d09:b44e hype.ippolitov.me
@@ -66,6 +65,7 @@ fc75:a699:c091:62a7:bae3:b1d8:1385:f55c ru.spb.atommixz.hype
 fc79:4516:3c53:f3de:4875:9e77:fb70:705c h.hitecnologys.org
 fc7d:1a8e:b4a4:15c1:6fb8:2d41:abe1:ca17 fvz-rec-fi-ulv-01 fvz-rec-fi-ulv-01.h.dnsrec.meo.ws
 fc7d:ab19:d6f3:c721:afff:49bc:8749:3890 ru.msk-hx.hype
+fc7e:9262:cf2a:eef8:6b9d:34ca:bb53:fe66 h2.hitecnologys.org
 fc7e:f26f:4e28:f5c3:5d79:149d:51f5:7c2d fvz-rec-ro-bu-01 fvz-rec-ro-bu-01.h.dnsrec.meo.ws
 fc7f:3d04:419f:e9b0:526f:fc6a:576:cba0 h.amadeu.berlinmesh.net
 fc80:2426:bdb4:4000:4161:30d4:5d14:2e71 fvz-rec-nl-fl-01 fvz-rec-nl-fl-01.h.dnsrec.meo.ws


### PR DESCRIPTION
Moved it to new site and, since both nodes I had were running simultaneously to ensure zero downtime, I had to generate new key pair. Then I decided to keep it this way. Hope this doesn't break anything.
