### PR TITLE
New CWINFO nodes

### DIFF
--- a/nodes
+++ b/nodes
@@ -78,6 +78,7 @@ fc46:969d:75a7:b38e:1c2e:954b:3c24:a9a3 h.ca.hub.icfreedom.net
 fc46:d480:61bb:658e:8936:4547:70ea:f628 rainbow.exit.li
 fc47:fa91:dfc5:d6a4:c428:be6b:d16:bdef h.rethymno-meshnet.tk
 fc48:238f:1b3b:e867:4f77:3fe1:8d09:b44e hype.ippolitov.me
+fc49:33c4:e12b:628e:bf18:e6eb:eb27:d60e fi1.servers.devices.h.cwinfo.net
 fc49:4bb0:30f4:5ea5:eaa:1484:7d37:68ef  h.xmpp.rows.io
 fc49:606:2d90:d40c:780c:277c:f2fc:a66d lucernal.qgqv.tk
 fc49:8be3:42b7:4f0c:4e68:563f:dac6:e259 lukevers.com
@@ -108,6 +109,7 @@ fc59:d9d1:2739:ca8d:b48a:45a5:352a:be35 peer1.fc00.org
 fc5a:62a6:094c:2fbc:c591:b471:f175:afef echelon.devices.h.christerwaren.fi
 fc5a:c8f7:2098:55b8:5309:12c4:cbc6:7b5b h.relpda.mikaela.info
 fc5b:22d1:ea43:6efc:bbe0:8eb8:8145:428d h.hub.icfreedom.net
+fc5b:7a1f:99c8:7c61:c626:6719:7e36:a9bb papyrus.fr1.servers.devices.h.cwinfo.net
 fc5b:9736:b91a:8c0e:33c0:95e4:2563:2ff4 yellow-poplar.niles.xyz
 fc5e:1bc7:c31c:993b:a784:cb7b:bf97:e2d3 fvz-rec-us-fl-01 fvz-rec-us-fl-01.h.dnsrec.meo.ws
 fc5e:67ca:df62:a01e:b525:82c4:6466:2b12 h.74.leipzig.freifunk.net
@@ -135,6 +137,7 @@ fc6d:2b11:4680:1c9a:5f05:8cea:4332:5e1c fvz-rec-ch-zrh-01 fvz-rec-ch-zrh-01.h.dn
 fc6d:c723:8c35:4f98:f1f8:7a12:ed05:61f3 fvz-rec-au-nsw-01 fvz-rec-au-nsw-01.h.dnsrec.meo.ws
 fc6e:691e:dfaa:b992:a10a:7b49:5a1a:5e09 peer2.h.e-mesh.net
 fc6e:9c71:5c46:5c72:c768:1d74:8887:c3d fvz-rec-sg-ea-01 fvz-rec-sg-ea-01.h.dnsrec.meo.ws
+fc6f:c821:925e:35fb:5e06:219c:bc59:4799 pl1.servers.devices.h.cwinfo.net
 fc70:4105:4cb2:c974:bf64:170f:04b1:ade5 h.bunjlabs.com
 fc72:2d6b:172f:f22b:f9f7:0bad:20e4:003f node0.vanmesh.net
 fc72:c065:f915:838e:f158:2242:a871:c719 h.darkcloud.ca
@@ -294,6 +297,7 @@ fcf4:e309:14b5:5498:cafd:4f59:4b9c:7f84 h.vps.cjdns.ca irc.hypeirc.net
 fcf5:894b:a246:fa31:f395:6e8d:31b6:f9f9 h.nup.pw
 fcf6:b259:3437:7641:cd74:7604:ffb7:d978 h.yakamo.org
 fcfa:be9c:c50d:391e:299b:ed37:4207:d72f fvz-rec-it-mi-01 fvz-rec-it-mi-01.h.dnsrec.meo.ws
+fcfc:44a2:66d4:6fe8:1e8b:41ec:8655:8f24 de1.servers.devices.h.cwinfo.net
 fcfc:5d70:99b6:4e0c:cba6:61ec:434b:df1a h.julian.meshwith.me
 fcfc:b6aa:665:755e:4772:2a54:9277:3ab5 h.fa3.us
 fcfd:9511:69cc:a05e:4eb2:ed20:c6a0:52e3 hyperboria.name


### PR DESCRIPTION
## CWINFO (@cwinfo)
fc49:33c4:e12b:628e:bf18:e6eb:eb27:d60e fi1.servers.devices.h.cwinfo.net
fc5b:7a1f:99c8:7c61:c626:6719:7e36:a9bb papyrus.fr1.servers.devices.h.cwinfo.net
fc6f:c821:925e:35fb:5e06:219c:bc59:4799 pl1.servers.devices.h.cwinfo.net
fcfc:44a2:66d4:6fe8:1e8b:41ec:8655:8f24 de1.servers.devices.h.cwinfo.net